### PR TITLE
Deixando h1 de sponsors igual aos outros

### DIFF
--- a/_sass/modules/_sponsors.scss
+++ b/_sass/modules/_sponsors.scss
@@ -21,7 +21,6 @@
   }
 
   h1, h2 {
-    font-family: "Panton Light";
     text-align: center;
     color: #333;
   }


### PR DESCRIPTION
A fonte estava diferente, portanto ficou um aspecto estranho no h1 dos patrocinadores, o que pode pegar mal, pois eles são muito queridos <3

Antes:
![image](https://user-images.githubusercontent.com/1902333/35402444-c5fb6636-01e3-11e8-8363-69095a1104bd.png)

Depois:
![image](https://user-images.githubusercontent.com/1902333/35402457-cff061d2-01e3-11e8-9031-4b0eba6ac6c9.png)
