### PR TITLE
Atualizar o dia ativo da agenda para hoje 

### DIFF
--- a/_data/agenda/day01.yaml
+++ b/_data/agenda/day01.yaml
@@ -5,7 +5,7 @@ header: Palestras e Tutoriais
 description: Palestras de 35 a 50 minutos e tutoriais com tempos variados, com palestrantes renomados da comunidade.
 place_name: BandTec Digital School
 place_link: https://goo.gl/FgJHvA
-is_active: true
+is_active: false
 
 agenda:
   - hour: '08:00'

--- a/_data/agenda/day02.yaml
+++ b/_data/agenda/day02.yaml
@@ -5,7 +5,7 @@ header: Palestras e Tutoriais
 description: Palestras de 35 a 50 minutos e tutoriais com tempos variados, com palestrantes renomados da comunidade.
 place_name: BandTec Digital School
 place_link: https://goo.gl/FgJHvA
-is_active: false
+is_active: true
 
 agenda:
   - hour: '08:00'


### PR DESCRIPTION
Ao entrar no site, aparece o dia de hoje como ativo.
![image](https://user-images.githubusercontent.com/11703235/38163559-f2892394-34cb-11e8-8d6c-c09204a49a8f.png)
